### PR TITLE
Correct Dockerfile for ARM

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,7 +1,7 @@
 # declare build option ARCH
 ARG ARCH=
 # download ARCH-specific base image if specified
-FROM ${ARCH}alpine:3
+FROM alpine:latest
 # decide which kiwix arch to download later (`armhf` for all arm* and x86_64 otherwise)
 ARG ARCH
 RUN if [ $(echo $ARCH | cut -c 1-3) = "arm" ] ; then echo "armhf" > /etc/kiwix_arch ; else echo "x86_64" > /etc/kiwix_arch ; fi


### PR DESCRIPTION
Original base image fails pull when using example command for ARM from modification made in #405:

$ docker build . -t kiwix/kiwix-serve:latest --build-arg ARCH="arm32v7a/"
Sending build context to Docker daemon  3.584kB
Step 1/14 : ARG ARCH=
Step 2/14 : FROM ${ARCH}alpine:3
pull access denied for arm32v7a/alpine, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

Returned to original alpine:latest because this functions for ARM as well.